### PR TITLE
Simplify interface and don't duplicate immutable sinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,86 +5,77 @@ A library for creating streams with multiple transformations and multiple consum
 Like a network of pipes you can apply transformations to your data and collect the results along the way.
 
 ## Examples
-* Every function creates it's own pipe which can independently transform and filter data allowing you to process a stream in multiple ways at once. 
-  ```kotlin
-  val data = listOf("ruby", "sapphire", "onyx", "emerald", "diamond")
-  val pipe = pipeFor(data) // type matching or Pipe<String>()
-  
-  val capitalize = pipe.map { it[0].uppercase() + it.substring(1) }
-  val longNames = pipe.filter { it.length > 5 }
-  val capitalizedShortNames = capitalize.filter { it.length < 5 }
-  
-  // Create sinks
-  val longNamesSink = longNames.sink()
-  val capitalizedShortNamesSink = capitalizedShortNames.sink()
-  
-  println(longNamesSink.get()) // [] no data piped yet
-  
-  data.source().pipe(pipe) // pipe the data from a source
-  
-  println(longNamesSink.get()) // [sapphire, emerald, diamond]
-  println(capitalizedShortNamesSink.get()) // [Ruby, Onyx]
-  ```
+* Every function creates its own pipe which can independently transform and filter data allowing you to process a stream in multiple ways at once.
+```kotlin
+val data = listOf("ruby", "sapphire", "onyx", "emerald", "diamond")
+val pipe = pipeFor(data) // type matching or Pipe<String>()
+
+// No sink, the values here won't be retrievable
+val capitalize = pipe.map { it[0].uppercase() + it.substring(1) }
+
+// Primary sink `sink()` can be retrieved later with `result()`
+val longNames = pipe.filter { it.length > 5 }.sink()
+
+// Pass your own collection to sink() and it will fill that (this is not a primary sink)
+val capitalizedShortNamesList = mutableListOf<String>()
+val capitalizedShortNames = capitalize.filter { it.length < 5 }.sink(capitalizedShortNamesList)
+
+val longestName = capitalize.reduce { acc: String, it: String -> if (acc.length > it.length) acc else it }
+// supplier interface for singular results
+val longestNameResult = longestName.sinkValue()
+
+println(longNames.result()) // [] no data piped yet
+
+data.source().pipe(pipe) // pipe the data from a source
+
+println(longNames.result()) // [sapphire, emerald, diamond]
+// println(capitalizedShortNames.result()) // Error - capitalizedShortNames doesn't have a primary sink
+println(capitalizedShortNamesList) // [Ruby, Onyx]
+println(longestNameResult.get()) // Sapphire
+```
 * Extend Pipe and override accept to chose how data is is aggregated and when it gets passed on.
-  ```kotlin
-  class AddPairs : Pipe<Int>() {
-    private var prev: Int? = null
+```kotlin
+class AddPairs : Pipe<Int>() {
+  private var prev: Int? = null
 
-    override fun accept(elem: Int, last: Boolean) {
-      val next = next(elem)
-      if (next != null) {
-        super.accept(next, last)
-      }
-    }
-  
-    fun next(cur: Int): Int? {
-      if (prev == null) {
-        prev = cur
-        return null
-      }
-      val sum = cur + prev!!
-      prev = null
-      return sum
+  override fun accept(elem: Int, last: Boolean) {
+    val next = next(elem)
+    if (next != null) {
+      super.accept(next, last)
     }
   }
-  ```
+
+  fun next(cur: Int): Int? {
+    if (prev == null) {
+      prev = cur
+      return null
+    }
+    val sum = cur + prev!!
+    prev = null
+    return sum
+  }
+}
+```
 * Extend TransformPipe if your transformation changes the type of your data
-  ```kotlin
-  class Derivative : TransformPipe<Point, Double>() {
-    override fun accept(elem: Point, last: Boolean) {
-      val next = transform(elem, last)
-      if (next != null) {
-        super.sinkAccept(next, last)
-      }
-    }
-  
-    private var prev: Point? = null
-    override fun transform(elem: Point, last: Boolean): Double? {
-      if (prev == null) {
-        prev = elem
-        return null
-      }
-      val derivative = (elem.y - prev!!.y) / (elem.x - prev!!.x)
-      prev = elem
-      return derivative
+```kotlin
+class Derivative : TransformPipe<Point, Double>() {
+  private var prev: Point? = null
+
+  override fun accept(elem: Point, last: Boolean) {
+    val next = transform(elem, last)
+    if (next != null) {
+      super.sinkAccept(next, last)
     }
   }
-  ```
 
-## Future:
-* I don't like the verbosity of having to declare the pipe and sink separately.
-* Maybe something like this would be better:
-    ```kotlin
-    val data = listOf("ruby", "sapphire", "onyx", "emerald", "diamond")
-    val pipe = pipeFor(data) // type matching or Pipe<String>()
-
-    val capitalize = pipe.map { it[0].uppercase() + it.substring(1) }
-    val longNames = pipe.filter { it.length > 5 }.withSink() // attach sink here
-    val capitalizedShortNames = capitalize.filter { it.length < 5 }.withSink()
-
-    data.source().pipe(pipe) // pipe the data from a source
-
-    println(capitalize.getSink()) // error - no sink was created
-    println(longNames.getSink()) // [sapphire, emerald, diamond]
-    println(capitalizedShortNames.getSink()) // [Ruby, Onyx]
-    ```
+  override fun transform(elem: Point, last: Boolean): Double? {
+    if (prev == null) {
+      prev = elem
+      return null
+    }
+    val derivative = (elem.y - prev!!.y) / (elem.x - prev!!.x)
+    prev = elem
+    return derivative
+  }
+}
+```

--- a/src/main/kotlin/me/theos/pipedream/FunctionalPipes.kt
+++ b/src/main/kotlin/me/theos/pipedream/FunctionalPipes.kt
@@ -41,7 +41,7 @@ internal class BiFunctionalPipe<T, R>(private val fn: BiFunction<T, Boolean, R>)
   }
 }
 
-internal class FilterPipe<T>(private var fn: Predicate<T>) : Pipe<T>(), Pipeable<T> {
+internal class FilterPipe<T>(private var fn: Predicate<T>) : Pipe<T>() {
   override fun accept(elem: T, last: Boolean) {
     if (fn.test(elem)) {
       super.accept(elem, last)
@@ -49,7 +49,7 @@ internal class FilterPipe<T>(private var fn: Predicate<T>) : Pipe<T>(), Pipeable
   }
 }
 
-internal class ReductionPipe<T>(private val fn: BiFunction<T, T, T>) : Pipe<T>(), Sinkable<T> {
+internal class ReductionPipe<T>(private val fn: BiFunction<T, T, T>) : Pipe<T>() {
   private var acc: T? = null
 
   override fun toString(): String {

--- a/src/main/kotlin/me/theos/pipedream/Pipeable.kt
+++ b/src/main/kotlin/me/theos/pipedream/Pipeable.kt
@@ -15,11 +15,12 @@ interface Pipeable<T> : Sinkable<T> {
   fun <R> biMap(transform: BiFunction<T, Boolean, R>): Pipeable<R>
   fun filter(predicate: (T) -> Boolean): Pipeable<T>
   fun filter(predicate: Predicate<T>): Pipeable<T>
-  fun sink(): SinkCollection<T>
-  fun sink(sink: MutableCollection<T>): SinkCollection<T>
-  fun sink(sink: (T) -> Unit)
-  fun sink(sink: Consumer<T>)
-  fun sink(sink: Sinkable<T>)
+  fun result(): List<T>
+  fun sink(): Pipeable<T>
+  fun sink(sink: MutableCollection<T>): Pipeable<T>
+  fun sink(sink: (T) -> Unit): Pipeable<T>
+  fun sink(sink: Consumer<T>): Pipeable<T>
+  fun sink(sink: Sinkable<T>): Pipeable<T>
   fun sinkValue(): Supplier<T>
   fun reduce(reducer: (acc: T, it: T) -> T): Pipeable<T>
   fun reduce(reducer: BiFunction<T, T, T>): Pipeable<T>

--- a/src/main/kotlin/me/theos/pipedream/Sink.kt
+++ b/src/main/kotlin/me/theos/pipedream/Sink.kt
@@ -4,17 +4,13 @@ import com.google.common.base.Preconditions
 import java.util.function.Consumer
 import java.util.function.Supplier
 
-class SinkCollection<T>(private val sink: MutableCollection<T>) : Sinkable<T>, Iterable<T>, Supplier<List<T>> {
+internal class SinkCollection<T>(private val sink: MutableCollection<T>) : Sinkable<T> {
   override fun accept(elem: T, last: Boolean) {
     sink.add(elem)
   }
 
-  override fun get(): List<T> {
+  fun toList(): List<T> {
     return sink.toList()
-  }
-
-  override fun iterator(): Iterator<T> {
-    return sink.iterator()
   }
 
   override fun toString(): String {
@@ -22,7 +18,7 @@ class SinkCollection<T>(private val sink: MutableCollection<T>) : Sinkable<T>, I
   }
 }
 
-class SinkValue<T> : Sinkable<T>, Supplier<T> {
+internal class SinkValue<T> : Sinkable<T>, Supplier<T> {
   private var value: T? = null
 
   override fun get(): T {
@@ -41,7 +37,7 @@ class SinkValue<T> : Sinkable<T>, Supplier<T> {
 }
 
 
-class SinkConsumer<in T>(private val sink: Consumer<T>) : Sinkable<T> {
+internal class SinkConsumer<in T>(private val sink: Consumer<T>) : Sinkable<T> {
   override fun accept(elem: T, last: Boolean) {
     sink.accept(elem)
   }

--- a/src/test/kotlin/me/theos/pipedream/PipeTest.kt
+++ b/src/test/kotlin/me/theos/pipedream/PipeTest.kt
@@ -23,8 +23,8 @@ internal class PipeTest {
     val pipe2 = Pipe<String>().filter { it == "one" }
     val sink = pipe.into(pipe2).sink()
     elements.source().pipe(pipe)
-    assertTrue(sink.get().size == 1)
-    assertEquals(sink.get().first(), elements.first())
+    assertTrue(sink.result().size == 1)
+    assertEquals(sink.result().first(), elements.first())
   }
 
   @Test
@@ -35,7 +35,7 @@ internal class PipeTest {
     }
     val sink = pipe.into(pipe2).sink()
     elements.source().pipe(pipe)
-    assertEquals(sink.get(), elements.map { it.length })
+    assertEquals(sink.result(), elements.map { it.length })
   }
 
   @Test
@@ -43,7 +43,7 @@ internal class PipeTest {
     val elements = listOf("one", "two", "three", "four")
     val sink = pipe.map { it.length } .sink()
     elements.source().pipe(pipe)
-    assertEquals(sink.get(), elements.map { it.length })
+    assertEquals(sink.result(), elements.map { it.length })
   }
 
   @Test
@@ -51,7 +51,7 @@ internal class PipeTest {
     val elements = listOf("one", "two", "three", "four")
     val sink = pipe.biMap { it, last -> if (last) 0 else it.length }.sink()
     elements.source().pipe(pipe)
-    assertEquals(sink.get(), elements.map { if (it == "four") 0 else it.length })
+    assertEquals(sink.result(), elements.map { if (it == "four") 0 else it.length })
   }
 
   @Test
@@ -59,8 +59,8 @@ internal class PipeTest {
     val elements = listOf("one", "two", "three", "four")
     val sink = pipe.filter { it.length % 2 == 1 }.sink()
     elements.source().pipe(pipe)
-    assertFalse(sink.get().contains("four"))
-    sink.get().forEach { assertTrue(elements.contains(it)) }
+    assertFalse(sink.result().contains("four"))
+    sink.result().forEach { assertTrue(elements.contains(it)) }
   }
 
   @Test
@@ -68,7 +68,7 @@ internal class PipeTest {
     val elements = listOf("one", "two", "three", "four")
     val sink = pipe.reduce { a, b -> "$a$b" }.sink()
     elements.source().pipe(pipe)
-    assertEquals(sink.get().first(), elements.reduce { acc, s -> acc + s })
+    assertEquals(sink.result().first(), elements.reduce { acc, s -> acc + s })
   }
 
   @Test
@@ -76,7 +76,7 @@ internal class PipeTest {
     val elements = listOf("one", "two", "three", "four")
     val sink = pipe.reduce(0) { a, b -> a + b.length }.sink()
     elements.source().pipe(pipe)
-    assertEquals(sink.get().first(), elements.fold(0) { acc, s -> acc + s.length })
+    assertEquals(sink.result().first(), elements.fold(0) { acc, s -> acc + s.length })
   }
 
   @Test
@@ -84,24 +84,23 @@ internal class PipeTest {
     val elements = listOf("one", "two", "three", "four")
     val sink = pipe.fold(0) { a, b -> a + b.length }.sink()
     elements.source().pipe(pipe)
-    assertEquals(sink.get().first(), elements.fold(0) { acc, s -> acc + s.length })
+    assertEquals(sink.result().first(), elements.fold(0) { acc, s -> acc + s.length })
   }
 
   @Test
-  fun testSinkCollection() {
+  fun testPrimarySinkCollection() {
     val elements = listOf("one", "two", "three", "four")
     val sink = pipe.sink()
     elements.source().pipe(pipe)
-    assertEquals(sink.get(), elements)
+    assertEquals(sink.result(), elements)
   }
 
   @Test
-  fun testSinkCollectionWithList() {
+  fun testListSinkCollection() {
     val elements = listOf("one", "two", "three", "four")
     val lis = mutableListOf<String>()
-    val sink = pipe.sink(lis)
+    pipe.sink(lis)
     elements.source().pipe(pipe)
-    assertEquals(sink.get(), lis)
     assertEquals(elements, lis)
   }
 
@@ -109,7 +108,7 @@ internal class PipeTest {
   fun testSinkConsumer() {
     val elements = listOf("one", "two", "three", "four")
     var value = elements[0]
-    pipe.sink { s -> value = s }
+    pipe.sink { value = it }
     elements.forEach { pipe.accept(it, false).run { assertEquals(it, value) } }
   }
 

--- a/src/test/kotlin/me/theos/pipedream/SinkCollectionTest.kt
+++ b/src/test/kotlin/me/theos/pipedream/SinkCollectionTest.kt
@@ -29,19 +29,6 @@ internal class SinkCollectionTest {
     val produced = setOf("One", "Two", "Three")
     val sink = SinkCollection(sinkList)
     produced.forEach { sink.accept(it, false) }
-    assertEquals(sink.get(), sinkList)
-  }
-
-  @Test
-  fun testSinkReturnsIterator() {
-    val produced = setOf("One", "Two", "Three")
-    val sink = SinkCollection(sinkList)
-    produced.forEach { sink.accept(it, false) }
-    sink.iterator().let { it1 ->
-      sinkList.iterator().let { it2 ->
-        assertEquals(it1.hasNext(), it2.hasNext())
-        assertEquals(it1.next(), it2.next())
-      }
-    }
+    assertEquals(sink.toList(), sinkList)
   }
 }

--- a/src/test/kotlin/me/theos/pipedream/TransformPipeTest.kt
+++ b/src/test/kotlin/me/theos/pipedream/TransformPipeTest.kt
@@ -39,6 +39,6 @@ internal class TransformPipeTest {
         pipe.accept(it.next(), !it.hasNext())
       }
     }
-    assertEquals(elements.filter(fn1).map(fn2), sink.get())
+    assertEquals(elements.filter(fn1).map(fn2), sink.result())
   }
 }


### PR DESCRIPTION
* Don't duplicate immutable sinks
  * Default sink collection is opaque and the result is always returned immutable
* Simplify Sink types since only the resulting collection seems to be useful
* Add a reusable "primary" sink with `sink()` that can be retrieved with `result()`
  * Results from this sink are immutable, so it's safe to be shared
* Fixed up some sneaky issues with lambda's and java interfaces
  * You can't cast from `Function<T, R>` to `(T) -> R` it seems