### PR TITLE
Add activity feed API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR
Created a new Express server with a mock activity feed endpoint

### What changed?
- Created a new Express server implementation in `server.js`
- Added a `/feed` endpoint that returns mock activity data
- Configured server to run on port 3000
- Implemented sample activity feed data with three mock entries

### How to test?
1. Start the server: `node server.js`
2. Send a GET request to `http://localhost:3000/feed`
3. Verify the response contains the mock activity feed data with three entries
4. Confirm the server logs show it's running on port 3000

### Why make this change?
To provide a basic API endpoint for retrieving activity feed data, which can be used for frontend development and testing without requiring a full backend implementation. This serves as a foundation for building out the activity feed feature.